### PR TITLE
Add a generic `revision` option to `git-import`

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,24 +18,27 @@ func main() {
 	dir := flag.String("dir", "", "the location to put the cloned repository")
 	branch := flag.String("branch", "", "the repository branch to clone")
 	tag := flag.String("tag", "", "the tag to clone")
+	revision := flag.String("revision", "", "a specific revision to checkout")
 	flag.Parse()
 
-	err := Clone(*url, *dir, *branch, *tag)
+	err := Clone(*url, *dir, *branch, *tag, *revision)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"url":    *url,
-			"dir":    *dir,
-			"branch": *branch,
-			"tag":    *tag,
-			"error":  err,
+			"url":      *url,
+			"dir":      *dir,
+			"branch":   *branch,
+			"tag":      *tag,
+			"revision": *revision,
+			"error":    err,
 		}).Error("Error cloning git repository")
 		os.Exit(1)
 	}
 }
 
 // Clone clones the git repository at the specified url to the given location
-// Using a 1-commit clone of the given branch
-func Clone(url string, dir string, branch string, tag string) error {
+// If cloning a tag or branch, using a 1-commit Clone
+// Otherwise the whole repo has to be cloned
+func Clone(url string, dir string, branch string, tag string, revision string) error {
 	err1 := ssh.Check(url)
 	if err1 != nil {
 		return fmt.Errorf("git-import: unable to import from [%s] due to error : %w", url, err1)
@@ -43,26 +46,36 @@ func Clone(url string, dir string, branch string, tag string) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 300*time.Second)
 	defer cancel()
 
-	if tag == "" && branch == "" {
-		return fmt.Errorf("Please specify either a branch or a tag.")
+	tag_exists := tag != ""
+	branch_exists := branch != ""
+	revision_exists := revision != ""
+	if !tag_exists && !branch_exists && !revision_exists {
+		return fmt.Errorf("Please specify either a branch, a tag, or a revision")
 	}
 
-	if tag != "" && branch != "" {
-		return fmt.Errorf("Please specify only the branch or only the tag.")
+	if (tag_exists && branch_exists) || ((tag_exists || branch_exists) && revision_exists) {
+		return fmt.Errorf("Please specify only the branch, only the tag, or only the revision.")
 	}
 
 	var referenceName plumbing.ReferenceName
-	if branch != "" {
+	if branch_exists {
 		referenceName = plumbing.NewBranchReferenceName(branch)
 	}
 	// Tags take precedence over branches so even if a branch was previously specified, we override the reference name with a tag
-	if tag != "" {
+	if tag_exists {
 		referenceName = plumbing.NewTagReferenceName(tag)
 	}
 
-	_, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{
+	cloneDepth := 1
+
+	// If a revision has a commit hash, we can't clone 1 commit
+	if revision_exists {
+		cloneDepth = 0
+	}
+
+	r, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{
 		URL:           url,
-		Depth:         1,
+		Depth:         cloneDepth,
 		Progress:      os.Stdout,
 		SingleBranch:  true,
 		ReferenceName: referenceName,
@@ -70,6 +83,33 @@ func Clone(url string, dir string, branch string, tag string) error {
 	if err != nil {
 		return err
 	}
+	// go-git cannot clone with an arbitrary revision. We'll have to checkout if a revision was passed
+	if revision_exists {
+		err := checkoutRevision(r, revision)
+		if err != nil {
+			// on error, we should remove the repo to match the previous behaviour of a failed clone
+			os.RemoveAll(dir)
+			return err
+		}
+	}
 
+	return nil
+}
+
+func checkoutRevision(repo *git.Repository, revision string) error {
+	// ResolveRevision will give us a hash to checkout (if the revision exists)
+	h, err := repo.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		return err
+	}
+	// Worktree cannot return an error because we cloned with isBare = false
+	w, _ := repo.Worktree()
+	// Finally, checkout the revision
+	err = w.Checkout(&git.CheckoutOptions{
+		Hash: *h,
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Main", func() {
 		dir       string
 		branch    string
 		tag       string
+		revision  string
 		pathToCMD string
 		session   *gexec.Session
 		command   *exec.Cmd
@@ -44,7 +45,8 @@ var _ = Describe("Main", func() {
 			dir = "test"
 			branch = "master"
 			tag = ""
-			command = exec.Command(pathToCMD, "-url", url, "-dir", dir, "-branch", branch, "-tag", tag)
+			revision = ""
+			command = exec.Command(pathToCMD, "-url", url, "-dir", dir, "-branch", branch, "-tag", tag, "-revision", revision)
 		})
 
 		It("should exit successfully", func() {
@@ -65,7 +67,8 @@ var _ = Describe("Main", func() {
 			dir = "test"
 			branch = "master"
 			tag = ""
-			command = exec.Command(pathToCMD, "-url", url, "-dir", dir, "-branch", branch, "-tag", tag)
+			revision = ""
+			command = exec.Command(pathToCMD, "-url", url, "-dir", dir, "-branch", branch, "-tag", tag, "-revision", revision)
 		})
 
 		It("should fail", func() {
@@ -82,6 +85,7 @@ var _ = Describe("Clone", func() {
 	var dir string
 	var branch string
 	var tag string
+	var revision string
 	var expectedFilePath string
 	var err error
 
@@ -90,6 +94,7 @@ var _ = Describe("Clone", func() {
 		dir = "test"
 		branch = ""
 		tag = ""
+		revision = ""
 		curPath, err := os.Getwd()
 		Expect(err).ShouldNot(HaveOccurred())
 		expectedFilePath = filepath.Join(curPath, dir, "README.md")
@@ -101,7 +106,7 @@ var _ = Describe("Clone", func() {
 		os.RemoveAll(filepath.Join(curPath, dir))
 	})
 
-	Context("with a valid public repo, valid path and filled branch and and empty tag", func() {
+	Context("with a valid public repo, valid path and filled branch and and empty tag and empty revision", func() {
 		BeforeEach(func() {
 			branch = "master"
 		})
@@ -111,7 +116,7 @@ var _ = Describe("Clone", func() {
 		})
 
 		It("should succeed", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			_, err := os.Stat(expectedFilePath)
@@ -119,7 +124,79 @@ var _ = Describe("Clone", func() {
 		})
 	})
 
-	Context("with a valid public repo, valid path and filled branch and filled tag", func() {
+	Context("with a valid public repo, valid path and empty branch and and filled tag and empty revision", func() {
+		BeforeEach(func() {
+			tag = "v1.0.0"
+		})
+
+		AfterEach(func() {
+			tag = ""
+		})
+
+		It("should succeed", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and empty branch and and empty tag and filled revision (branch)", func() {
+		BeforeEach(func() {
+			revision = "master"
+		})
+
+		AfterEach(func() {
+			revision = ""
+		})
+
+		It("should succeed", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and empty branch and and empty tag and filled revision (tag)", func() {
+		BeforeEach(func() {
+			revision = "v1.0.0"
+		})
+
+		AfterEach(func() {
+			revision = ""
+		})
+
+		It("should succeed", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and empty branch and and empty tag and filled revision (commit)", func() {
+		BeforeEach(func() {
+			revision = "c6ec0ddbb1a750e90e422653891ec8c3254e6c78"
+		})
+
+		AfterEach(func() {
+			revision = ""
+		})
+
+		It("should succeed", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and filled branch and filled tag and empty revision", func() {
 		BeforeEach(func() {
 			branch = "master"
 			tag = "v1.0.0"
@@ -131,18 +208,85 @@ var _ = Describe("Clone", func() {
 		})
 
 		It("should fail", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).Should(HaveOccurred())
-			Expect(strings.ToLower(err.Error())).Should(ContainSubstring("please specify only the branch or only the tag"))
+			Expect(strings.ToLower(err.Error())).Should(ContainSubstring("please specify only the branch, only the tag, or only the revision"))
 
 			_, err := os.Stat(expectedFilePath)
 			Expect(err).Should(HaveOccurred())
 		})
 	})
 
-	Context("with a valid public repo, valid path and empty branch and empty tag", func() {
+	Context("with a valid public repo, valid path and filled branch and filled tag and filled revision", func() {
+		BeforeEach(func() {
+			branch = "master"
+			tag = "v1.0.0"
+			revision = "v1.0.0"
+		})
+
+		AfterEach(func() {
+			branch = ""
+			tag = ""
+			revision = ""
+		})
+
 		It("should fail", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).Should(HaveOccurred())
+			Expect(strings.ToLower(err.Error())).Should(ContainSubstring("please specify only the branch, only the tag, or only the revision"))
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and filled branch and empty tag and filled revision", func() {
+		BeforeEach(func() {
+			branch = "master"
+			revision = "v1.0.0"
+		})
+
+		AfterEach(func() {
+			branch = ""
+			tag = ""
+			revision = ""
+		})
+
+		It("should fail", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).Should(HaveOccurred())
+			Expect(strings.ToLower(err.Error())).Should(ContainSubstring("please specify only the branch, only the tag, or only the revision"))
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path empty branch and filled tag and filled revision", func() {
+		BeforeEach(func() {
+			tag = "v1.0.0"
+			revision = "v1.0.0"
+		})
+
+		AfterEach(func() {
+			branch = ""
+			tag = ""
+			revision = ""
+		})
+
+		It("should fail", func() {
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).Should(HaveOccurred())
+			Expect(strings.ToLower(err.Error())).Should(ContainSubstring("please specify only the branch, only the tag, or only the revision"))
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and empty branch and empty tag and empty revision", func() {
+		It("should fail", func() {
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).Should(HaveOccurred())
 
 			_, err := os.Stat(expectedFilePath)
@@ -160,7 +304,7 @@ var _ = Describe("Clone", func() {
 		})
 
 		It("should fail", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).Should(HaveOccurred())
 
 			_, err := os.Stat(expectedFilePath)
@@ -178,7 +322,25 @@ var _ = Describe("Clone", func() {
 		})
 
 		It("should fail", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
+			Expect(err).Should(HaveOccurred())
+
+			_, err := os.Stat(expectedFilePath)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("with a valid public repo, valid path and an invalid revision", func() {
+		BeforeEach(func() {
+			revision = "#$%#"
+		})
+
+		AfterEach(func() {
+			revision = ""
+		})
+
+		It("should fail", func() {
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).Should(HaveOccurred())
 
 			_, err := os.Stat(expectedFilePath)
@@ -196,7 +358,7 @@ var _ = Describe("Clone", func() {
 		})
 
 		It("should fail", func() {
-			err = Clone(url, dir, branch, tag)
+			err = Clone(url, dir, branch, tag, revision)
 			Expect(err).Should(HaveOccurred())
 
 			_, err := os.Stat(expectedFilePath)


### PR DESCRIPTION
This PR adds a new option to `Clone` and the command line flags where the user can specify a generic Git 'revision'.

This is option is needed for the new SDK to be fully compatible with Orquestra Quantum Engine. (The SDK may not have access to the Git repository locally so cannot check if something is a branch, tag, or commit).

Pros:
- Backwards compatible. Anyone using `branch` with YAML workflows should see no change.
- Allows for selection of arbitrary branches/commits/tags without any need to change an option.

Downsides:
- The user may supply a revision that a depth = 1 clone doesn't know about. Because of this, if `revision` is used, the entire git repository should to be cloned.
----
I'm not 100% sure how QE calls `git-import`, my understanding at the moment is that it uses `qe-cli`. If that's true then these are the next steps:

- If approved, this would also require changes to `qe-cli` to fully implement. (A local prototype on my laptop exists)
- If rejected, the next step is to at least modify `qe-cli` to accept Git tags. The code in `git-import` already exists.
----
An example set of imports:
```yaml
imports:
  - name: by-branch
    type: git
    parameters:
      repository: git@github.com:zapatacomputing/z-quantum-core.git
      revision: main
  - name: by-tag
    type: git
    parameters:
      repository: git@github.com:zapatacomputing/z-quantum-core.git
      revision: v0.1.0
  - name: by-commit
    type: git
    parameters:
      repository: git@github.com:zapatacomputing/z-quantum-core.git
      revision: b9d92f70c8a37aacdeab125b31d0ebb384b65f19
```

Example in `python3-runtime` dev container, with modified `qe-cli`:

```
root@bb557967b07f:/app# ./qe-cli get imports -f /app/quantum-engine-runtimes-v1/imports.yaml
Successfully downloaded imports to /tmp/qe/imports.
root@bb557967b07f:/app# for i in /tmp/qe/imports/*; do pushd $i > /dev/null; echo $i,$(git show --oneline -s); popd > /dev/null; done
/tmp/qe/imports/by-branch,b1e68b3 Merge pull request #443 from zapatacomputing/dev
/tmp/qe/imports/by-commit,b9d92f7 ZQS-813 modify bitstring distribution file and adapt old tests
/tmp/qe/imports/by-tag,f285b29 Merge pull request #28 from zapatacomputing/readme-fixes
```